### PR TITLE
フラッシュメッセージを実装

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <TheHeader />
+    <TheFlash />
     <router-view />
     <TheFooter />
   </div>
@@ -9,10 +10,13 @@
 <script>
 import TheHeader from './components/TheHeader.vue'
 import TheFooter from './components/TheFooter.vue'
+import TheFlash from './components/TheFlash.vue'
+
 export default {
   components: { 
     TheFooter, 
-    TheHeader 
+    TheHeader,
+    TheFlash,
   },
 }
 </script>

--- a/app/javascript/components/TheFlash.vue
+++ b/app/javascript/components/TheFlash.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="message" v-if="message">
+    {{ message }}
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+
+export default {
+  name: 'TheFlash',
+  computed: {
+    ...mapGetters('flash', [ 'message' ]),
+  },
+}
+</script>
+
+<style scope>
+  .message {
+    text-align: center;
+    width: 60%;
+    margin: 0 auto;
+    padding: 20px;
+    background-color: aquamarine;
+    border-radius: 20px;
+  }
+</style>

--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
+import { mapGetters, mapMutations, mapActions } from 'vuex'
 
 export default {
   name: "TheHeader",
@@ -37,13 +37,16 @@ export default {
 
   methods: {
     ...mapActions('users', [ 'logoutUser' ]),
+    ...mapMutations('flash', [ 'setMessage' ]),
 
     async logout() {
       try {
         await this.logoutUser()
         this.$router.push({ name: 'JokeIndex' })
+        this.setMessage({ message: 'ログアウトしました', timeout: 3000 })
       } catch(error) {
         console.log(error);
+        this.setMessage({ message: 'ログアウトできませんでした', timeout: 3000 });
       }
     }
   }

--- a/app/javascript/pages/jokes/create.vue
+++ b/app/javascript/pages/jokes/create.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
+import { mapGetters, mapMutations, mapActions } from 'vuex'
 
 export default {
   name: "JokeCreate",
@@ -36,13 +36,16 @@ export default {
 
   methods: {
     ...mapActions('jokes', [ 'createJoke' ]),
+    ...mapMutations('flash', [ 'setMessage' ]),
 
     async handleCreateJoke() {
       try {
         await this.createJoke(this.joke);
         this.$router.push({ name: 'JokeIndex' });
+        this.setMessage({ message: 'あるあるネタを投稿しました', timeout: 3000 })
       } catch(error) {
         console.log(error);
+        this.setMessage({ message: 'あるあるネタを投稿できませんでした', timeout: 3000 });
       }
     }
   },

--- a/app/javascript/pages/jokes/index.vue
+++ b/app/javascript/pages/jokes/index.vue
@@ -26,7 +26,7 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
+import { mapGetters, mapMutations, mapActions } from 'vuex'
 
 export default {
   name: 'JokeIndex',
@@ -45,12 +45,15 @@ export default {
 
   methods: {
     ...mapActions('jokes', [ 'fetchJokes', 'deleteJoke' ]),
+    ...mapMutations('flash', [ 'setMessage' ]),
 
     async handleDeleteJoke(joke) {
       try {
         await this.deleteJoke(joke)
+        this.setMessage({ message: 'あるあるネタを削除しました', timeout: 3000 })
       } catch(error) {
         console.log(error)
+        this.setMessage({ message: 'あるあるネタを削除できませんでした', timeout: 5000 });
       }
     },
 

--- a/app/javascript/pages/login/index.vue
+++ b/app/javascript/pages/login/index.vue
@@ -26,7 +26,7 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex'
+import { mapMutations, mapActions } from 'vuex'
 
 export default {
   name: 'UserLogin',
@@ -40,13 +40,16 @@ export default {
   },
   methods: {
     ...mapActions('users', [ 'loginUser' ]),
+    ...mapMutations('flash', [ 'setMessage' ]),
 
     async login() {
       try {
         await this.loginUser(this.user)
         this.$router.push({ name: 'JokeIndex' })
+        this.setMessage({ message: 'ログインしました', timeout: 3000 })
       } catch(error) {
           console.log(error);
+          this.setMessage({ message: 'ログインできませんでした', timeout: 3000 });
       }
     }
   }

--- a/app/javascript/pages/register/index.vue
+++ b/app/javascript/pages/register/index.vue
@@ -39,6 +39,8 @@
 </template>
 
 <script>
+import { mapMutations } from 'vuex'
+
 export default {
   name: "UserRegister",
   data() {
@@ -53,10 +55,15 @@ export default {
   },
 
   methods: {
+    ...mapMutations('flash', [ 'setMessage' ]),
+
     userRegister() {
       this.$axios.post('/users', { user: this.user })
         .then(res => {
-          this.$router.push({ name: 'JokeIndex' })
+          this.$router.push({ name: 'UserLogin' })
+          this.setMessage({ message: 'ユーザー登録しました', timeout: 3000 })
+        }).catch(err => {
+          this.setMessage({ message: 'ユーザー登録できませんでした', timeout: 3000 })
         })
     }
   }

--- a/app/javascript/router/index.js
+++ b/app/javascript/router/index.js
@@ -43,6 +43,7 @@ router.beforeEach((to, from, next) => {
   store.dispatch('users/fetchAuthUser').then((authUser) => {
     if (to.matched.some(record => record.meta.requiredAuth) && !authUser) {
       next({ name: 'UserLogin' });
+      store.commit('flash/setMessage', { message: 'ログインしてください', timeout: 3000 })
     } else {
       next();
     }

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import Vuex from 'vuex'
 import jokes from './modules/jokes'
 import users from './modules/users'
+import flash from './modules/flash'
 
 Vue.use(Vuex)
 
@@ -9,5 +10,6 @@ export default new Vuex.Store({
   modules: {
     jokes,
     users,
+    flash,
   }
 })

--- a/app/javascript/store/modules/flash.js
+++ b/app/javascript/store/modules/flash.js
@@ -1,0 +1,26 @@
+const state = {
+  message: ''
+}
+
+const getters = {
+  message: state => state.message
+}
+
+const mutations = {
+  setMessage (state, { message, timeout }) {
+    state.message = message
+
+    if (typeof timeout === 'undefined') {
+      timeout = 3000
+    }
+
+    setTimeout(() => (state.message = null), timeout)
+  }
+}
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  mutations,
+}


### PR DESCRIPTION
close #24 
## 概要

- フラッシュメッセージを実装
  - フラッシュメッセージ専用のstoreを作成


## 確認方法

下記の時にフラッシュメッセージが表示されること
- ユーザー登録成功
- ユーザー登録失敗
- ログイン成功
- ログイン失敗
- ログアウト時
- あるあるネタ投稿成功
- あるあるネタ投稿失敗
- あるあるネタ投稿削除
- 未ログインでログイン必須画面に行った場合