### PR TITLE
ソート機能を追加

### DIFF
--- a/app/controllers/api/jokes_controller.rb
+++ b/app/controllers/api/jokes_controller.rb
@@ -1,6 +1,6 @@
 class Api::JokesController < ApplicationController
   def index
-    jokes = Joke.includes(:user)
+    jokes = Joke.all.sort { |a, b| b.vote_count <=> a.vote_count }
     render json: jokes
   end
 

--- a/app/controllers/api/votes_controller.rb
+++ b/app/controllers/api/votes_controller.rb
@@ -3,16 +3,12 @@ class Api::VotesController < ApplicationController
     votes = Vote.all
     render json: votes
   end
-  
+
   def create
     joke = Joke.find(params[:joke_id])
     vote = joke.votes.create!
-    render json: vote
-  end
-
-  def destroy
-    vote = Vote.find(params[:id])
-    vote.destroy!
+    count = joke.vote_count + 1
+    joke.update!(vote_count: count)
     render json: vote
   end
 end

--- a/app/javascript/pages/jokes/index.vue
+++ b/app/javascript/pages/jokes/index.vue
@@ -4,6 +4,11 @@
       <p>日常生活で起きたあるあるネタをどんどん共有しましょう〜</p>
       <p>自分が面白いと思ったあるあるネタに投票しまくりましょう！</p>
     </div>
+    <div class="sort_btn">
+      <div class="btn btn-outline-secondary" @click="handleVoteSortJokes()">投票数順</div>
+      <div class="btn btn-outline-secondary" @click="handleDescSortJokes()">新しい順</div>
+      <div class="btn btn-outline-secondary" @click="handleAscSortJokes()">古い順</div>
+    </div>
     <div class="joke_list">
       <template v-for="joke in jokes" class="joke_item">
         <JokeItem 
@@ -27,15 +32,16 @@ export default {
   components: {
     JokeItem,
   },
+
   computed: {
     ...mapGetters('jokes', [ 'jokes' ]),
     ...mapGetters('users', [ 'authUser' ]),
     ...mapGetters('votes', [ 'votes' ]),
 
     filterVote() {
-      return function(value) {
+      return function(joke) {
         return this.votes.filter(vote => {
-          return vote.joke_id === value.id
+          return vote.joke_id === joke.id
         })
       }
     },
@@ -48,7 +54,8 @@ export default {
 
   methods: {
     ...mapMutations('flash', [ 'setMessage' ]),
-    ...mapActions('jokes', [ 'fetchJokes', 'deleteJoke' ]),
+    ...mapMutations('jokes', [ 'ascSortJokes', 'descSortJokes' ]),
+    ...mapActions('jokes', [ 'fetchJokes', 'deleteJoke', 'updateVoteSortJokes' ]),
     ...mapActions('votes', [ 'fetchVotes', 'createVote' ]),
 
     async handleDeleteJoke(joke) {
@@ -73,6 +80,18 @@ export default {
         console.log(error)
       }
     },
+
+    handleAscSortJokes() {
+      this.ascSortJokes()
+    },
+
+    handleDescSortJokes() {
+      this.descSortJokes()
+    },
+
+    handleVoteSortJokes() {
+      this.updateVoteSortJokes()
+    },
   },
 }
 </script>
@@ -81,6 +100,13 @@ export default {
   .introduction {
     text-align: center;
     margin: 40px 0;
+  }
+
+  .sort_btn {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 40px;
   }
 
   .joke_list {

--- a/app/javascript/store/modules/jokes.js
+++ b/app/javascript/store/modules/jokes.js
@@ -20,6 +20,21 @@ const mutations = {
       return joke.id != removeJoke.id
     })
   },
+  ascSortJokes: (state) => {
+    state.jokes.sort((a, b) => {
+      return a.id - b.id
+    })
+  },
+  descSortJokes: (state) => {
+    state.jokes.sort((a, b) => {
+      return b.id - a.id
+    })
+  },
+  voteSortJokes: (state) => {
+    state.jokes.sort((a, b) => {
+      return b.vote_count - a.vote_count
+    })
+  },
 }
 
 const actions = {
@@ -42,6 +57,13 @@ const actions = {
         commit('removeJoke', res.data)
       })
   },
+  updateVoteSortJokes({ commit }) {
+    axios.get('jokes')
+      .then(res => {
+        commit('setJokes', res.data)
+        commit('voteSortJokes')
+      })
+  }
 }
 
 export default {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :jokes, only: %i[index create destroy], shallow: true do
-      resources :votes, only: %i[create destroy]
+      resources :votes, only: %i[create]
     end
     resources :sessions, only: %i[create destroy]
     resources :users, only: %i[create] do

--- a/db/migrate/20210828140530_create_jokes.rb
+++ b/db/migrate/20210828140530_create_jokes.rb
@@ -2,6 +2,7 @@ class CreateJokes < ActiveRecord::Migration[6.0]
   def change
     create_table :jokes do |t|
       t.text :sentence, null: false
+      t.integer :vote_count, default: 0, null: false
       t.references :user, null: false, foreign_key: true
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,6 +14,7 @@ ActiveRecord::Schema.define(version: 2021_09_01_095007) do
 
   create_table "jokes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.text "sentence", null: false
+    t.integer "vote_count", default: 0, null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
close #28 
## 概要

- あるあるネタ一覧を、「投票数順」「新しい順」「古い順」にソートできるようにする

## 確認方法

- `投票数順`ボタンを押すと、投票数が多い順にソートされること。
- `新しい順`ボタンを押すと、新しく投稿された順にソートされること。
- `古い順`ボタンを押すと、投稿の古い順にソートされること。