### PR TITLE
投票数順ソート機能のバグを修正

### DIFF
--- a/app/controllers/api/jokes_controller.rb
+++ b/app/controllers/api/jokes_controller.rb
@@ -1,6 +1,6 @@
 class Api::JokesController < ApplicationController
   def index
-    jokes = Joke.all.sort { |a, b| b.vote_count <=> a.vote_count }
+    jokes = Joke.sort_votes
     render json: jokes
   end
 

--- a/app/controllers/api/votes_controller.rb
+++ b/app/controllers/api/votes_controller.rb
@@ -7,8 +7,6 @@ class Api::VotesController < ApplicationController
   def create
     joke = Joke.find(params[:joke_id])
     vote = joke.votes.create!
-    count = joke.vote_count + 1
-    joke.update!(vote_count: count)
     render json: vote
   end
 end

--- a/app/javascript/pages/jokes/index.vue
+++ b/app/javascript/pages/jokes/index.vue
@@ -85,7 +85,7 @@ export default {
   methods: {
     ...mapMutations('flash', [ 'setMessage' ]),
     ...mapMutations('jokes', [ 'ascSortJokes', 'descSortJokes' ]),
-    ...mapActions('jokes', [ 'fetchJokes', 'deleteJoke', 'updateVoteSortJokes' ]),
+    ...mapActions('jokes', [ 'fetchJokes', 'deleteJoke' ]),
     ...mapActions('votes', [ 'fetchVotes', 'createVote' ]),
     ...mapActions('users', [ 'fetchUsers' ]),
 
@@ -121,7 +121,7 @@ export default {
     },
 
     handleVoteSortJokes() {
-      this.updateVoteSortJokes()
+      this.fetchJokes()
     },
 
     scrollTop() {

--- a/app/javascript/store/modules/jokes.js
+++ b/app/javascript/store/modules/jokes.js
@@ -30,11 +30,11 @@ const mutations = {
       return b.id - a.id
     })
   },
-  voteSortJokes: (state) => {
-    state.jokes.sort((a, b) => {
-      return b.vote_count - a.vote_count
-    })
-  },
+  // voteSortJokes: (state) => {
+  //   state.jokes.sort((a, b) => {
+  //     return b.vote_count - a.vote_count
+  //   })
+  // },
 }
 
 const actions = {
@@ -57,13 +57,13 @@ const actions = {
         commit('removeJoke', res.data)
       })
   },
-  updateVoteSortJokes({ commit }) {
-    axios.get('jokes')
-      .then(res => {
-        commit('setJokes', res.data)
-        commit('voteSortJokes')
-      })
-  }
+  // updateVoteSortJokes({ commit }) {
+  //   axios.get('jokes')
+  //     .then(res => {
+  //       commit('setJokes', res.data)
+  //       commit('voteSortJokes')
+  //     })
+  // }
 }
 
 export default {

--- a/app/models/joke.rb
+++ b/app/models/joke.rb
@@ -3,4 +3,6 @@ class Joke < ApplicationRecord
   has_many :votes, dependent: :destroy
 
   validates :sentence, presence: true
+
+  scope :sort_votes, -> { sort { |a, b| b.votes.count <=> a.votes.count } }
 end

--- a/spec/system/jokes_spec.rb
+++ b/spec/system/jokes_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe "Jokes", type: :system do
       it '投稿が投票の多い順にソートされること' do
         visit root_path
         click_on '投票数順'
+        sleep 1
         joke_sentences = page.all('.joke_sentence')
         expect(joke_sentences[0].text).to eq  joke_with_3vote.sentence
         expect(joke_sentences[1].text).to eq  joke_with_2vote.sentence
@@ -94,6 +95,7 @@ RSpec.describe "Jokes", type: :system do
       it '投稿日時が新しい順にソートされること' do
         visit root_path
         click_on '新しい順'
+        sleep 1
         joke_sentences = page.all('.joke_sentence')
         expect(joke_sentences[0].text).to eq  joke_with_1vote.sentence
         expect(joke_sentences[1].text).to eq  joke_with_2vote.sentence
@@ -105,6 +107,7 @@ RSpec.describe "Jokes", type: :system do
       it '投稿日時が古い順にソートされること' do
         visit root_path
         click_on '古い順'
+        sleep 1
         joke_sentences = page.all('.joke_sentence')
         expect(joke_sentences[0].text).to eq  joke_with_3vote.sentence
         expect(joke_sentences[1].text).to eq  joke_with_2vote.sentence


### PR DESCRIPTION
close #55 
## 概要

**投票数ソート機能のバグを修正**
jokeモデルに`vote_count`というカラムを作り、投票の度にそのカラムの値を更新していたが、数千回くらい連打された際に、値の更新がうまくいかなかった。  
ソート機能では`vote_count`の値を基準にソートしていたので、関連付のメソッド(`joke.votes.count`)を使い、こちらの値を基準にソートするように修正。

## 確認方法

- 投票数ソート機能のバグを修正されていること。
